### PR TITLE
Add UDEV rules for the Lego USB IR Tower

### DIFF
--- a/debian/pbrick-rules.pbrick.udev
+++ b/debian/pbrick-rules.pbrick.udev
@@ -1,7 +1,7 @@
 # Rules for LEGO programmable bricks
 
 # MINDSTORMS RCX USB IR-Tower
-SUBSYSTEM=="usb", ATTRS{idVendor}=="0694", ATTRS{idProduct}=="0001", TAG+="uaccess"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0694", ATTRS{idProduct}=="0001", TAG+="uaccess", SYMLINK+="legousbtower-%k"
 
 # MINDSTORMS NXT brick 
 SUBSYSTEM=="usb", ATTRS{idVendor}=="0694", ATTRS{idProduct}=="0002", TAG+="uaccess"

--- a/debian/pbrick-rules.pbrick.udev
+++ b/debian/pbrick-rules.pbrick.udev
@@ -1,5 +1,8 @@
 # Rules for LEGO programmable bricks
 
+# MINDSTORMS RCX USB IR-Tower
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0694", ATTRS{idProduct}=="0001", TAG+="uaccess"
+
 # MINDSTORMS NXT brick 
 SUBSYSTEM=="usb", ATTRS{idVendor}=="0694", ATTRS{idProduct}=="0002", TAG+="uaccess"
 


### PR DESCRIPTION
Added a UDEV rule for the Lego USB IR Tower. An IR tower is required for interacting with the Mindstorms RCX, Spybotics, Scout, and Microscout PBricks and all Power Functions devices.